### PR TITLE
add ldap extended error

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -277,6 +277,9 @@ $default_action = "change";
 #$messages['passwordchangedextramessage'] = NULL;
 #$messages['changehelpextramessage'] = NULL;
 
+## show ldap extended error
+#$show_extented_ldap_error=true;
+
 # Launch a posthook script after successful password change
 #$posthook = "/usr/share/self-service-password/posthook.sh";
 

--- a/pages/change.php
+++ b/pages/change.php
@@ -199,6 +199,7 @@ if ( $result === "" ) {
     $ldap_extended_error = "" ;
     if ( $result === "passworderror" ) {
       ldap_get_option($ldap, LDAP_OPT_DIAGNOSTIC_MESSAGE, $ldap_extended_error);
+     $ldap_extended_error = "[" . $ldap_extended_error . "]";
    }
 
 }
@@ -209,7 +210,7 @@ if ( $result === "" ) {
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">
-<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result] . ":" . $ldap_extended_error ;  ?></p>
+<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result] . " " . $ldap_extended_error ;  ?></p>
 </div>
 
 <?php if ( $result !== "passwordchanged" ) { ?>

--- a/pages/change.php
+++ b/pages/change.php
@@ -19,7 +19,7 @@
 #
 #==============================================================================
 
-# define not available in php 5
+# missed defines in php 5
 define("LDAP_OPT_DIAGNOSTIC_MESSAGE", 0x0032);
 
 

--- a/pages/change.php
+++ b/pages/change.php
@@ -197,7 +197,7 @@ if ( $result === "" ) {
     }
  
     $ldap_extended_error = "" ;
-    if ( $result === "passworderror" ) {
+    if ( $result === "passworderror" && $show_extented_ldap_error  ) {
       ldap_get_option($ldap, LDAP_OPT_DIAGNOSTIC_MESSAGE, $ldap_extended_error);
      $ldap_extended_error = "[" . $ldap_extended_error . "]";
    }

--- a/pages/change.php
+++ b/pages/change.php
@@ -19,6 +19,11 @@
 #
 #==============================================================================
 
+# define not available in php 5
+define("LDAP_OPT_DIAGNOSTIC_MESSAGE", 0x0032);
+
+
+
 # This page is called to change password
 
 #==============================================================================
@@ -190,6 +195,12 @@ if ( $result === "" ) {
         $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword).' '.escapeshellarg($oldpassword);
         exec($command);
     }
+ 
+    $ldap_extended_error = "" ;
+    if ( $result === "passworderror" ) {
+      ldap_get_option($ldap, LDAP_OPT_DIAGNOSTIC_MESSAGE, $ldap_extended_error);
+   }
+
 }
 
 #==============================================================================
@@ -198,7 +209,7 @@ if ( $result === "" ) {
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">
-<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result]; ?></p>
+<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result] . ":" . $ldap_extended_error ;  ?></p>
 </div>
 
 <?php if ( $result !== "passwordchanged" ) { ?>

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -21,6 +21,9 @@
 
 # This page is called to reset a password when a valid token is found in URL
 
+# missed defines in php 5
+define("LDAP_OPT_DIAGNOSTIC_MESSAGE", 0x0032);
+
 #==============================================================================
 # POST parameters
 #==============================================================================

--- a/pages/resetbytoken.php
+++ b/pages/resetbytoken.php
@@ -203,6 +203,12 @@ if ($result === "") {
         $command = escapeshellcmd($posthook).' '.escapeshellarg($login).' '.escapeshellarg($newpassword);
         exec($command);
     }
+
+    $ldap_extended_error = "" ;
+    if ( $result === "passworderror" && $show_extented_ldap_error  ) {
+      ldap_get_option($ldap, LDAP_OPT_DIAGNOSTIC_MESSAGE, $ldap_extended_error);
+     $ldap_extended_error = "[" . $ldap_extended_error . "]";
+   }
 }
 
 # Delete token if all is ok
@@ -217,7 +223,7 @@ if ( $result === "passwordchanged" ) {
 ?>
 
 <div class="result alert alert-<?php echo get_criticity($result) ?>">
-<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result]; ?></p>
+<p><i class="fa fa-fw <?php echo get_fa_class($result) ?>" aria-hidden="true"></i> <?php echo $messages[$result] . " " . $ldap_extended_error ; ?></p>
 </div>
 
 <?php if ( $result !== "passwordchanged" ) { ?>


### PR DESCRIPTION
Hi,

I use OpenLDAP with ppolicy.
When use self-password , and get error from openldap, cause of "password policy" into openldap, "self-password return only "Password was refused by the LDAP directory".

Could you get the extended error to be able to display the message coming from openldap ?

I do the following change into "change.php", but I suppose that I must do also "setquestions.php", "resetbytoken.php" and "resetbyquestions.php" ?